### PR TITLE
fix(base): fix tanstack query config

### DIFF
--- a/src/app/api/query-client.ts
+++ b/src/app/api/query-client.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, type DefaultOptions } from "@tanstack/react-query";
 
 export const queryKeys = {
   zones: {
@@ -16,16 +16,18 @@ export type QueryKey =
 // first element of the queryKeys array
 export type QueryModel = QueryKey[number];
 
-export const defaultQueryOptions = {
-  staleTime: 5 * 60 * 1000, // 5 minutes
-  cacheTime: 15 * 60 * 1000, // 15 minutes
-  refetchOnWindowFocus: true,
-} as const;
+type QueryOptions = NonNullable<DefaultOptions>["queries"];
 
-export const realTimeQueryOptions = {
+export const defaultQueryOptions: QueryOptions = {
+  staleTime: 5 * 60 * 1000, // 5 minutes
+  gcTime: 15 * 60 * 1000, // 15 minutes
+  refetchOnWindowFocus: true,
+};
+
+export const realTimeQueryOptions: QueryOptions = {
   staleTime: 0,
-  cacheTime: 60 * 1000, // 1 minute
-} as const;
+  gcTime: 60 * 1000, // 1 minute
+};
 
 export const createQueryClient = () =>
   new QueryClient({

--- a/src/app/api/query/base.ts
+++ b/src/app/api/query/base.ts
@@ -55,7 +55,7 @@ export function useWebsocketAwareQuery<
   const connectedCount = useSelector(statusSelectors.connectedCount);
   const { subscribe } = useWebSocket();
 
-  const queryModelKey = Array.isArray(queryKey) ? queryKey[0] : "";
+  const queryModelKey = queryKey[0];
 
   useEffect(() => {
     queryClient.invalidateQueries();


### PR DESCRIPTION
## Done
- migrate v3 & v4 tanstack query options to v5 

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: conviguration of tanstack query - old APIs replaced by new equivalents

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

- `cacheTime` was renamed to `gcTime`  in v5 https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#rename-cachetime-to-gctime
- `queryKey` can't be a string since v4 https://tanstack.com/query/v4/docs/framework/react/guides/migrating-to-react-query-4#query-keys-and-mutation-keys-need-to-be-an-array
